### PR TITLE
Update WHMCSModuleTest.php

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.6/phpunit.xsd"
-    bootstrap="tests/_bootstrap.php"
-    cacheTokens="false"
->
-    <testsuites>
-        <testsuite name="WHMCS Sample Provisioning Module Tests">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/_bootstrap.php">
+  <coverage/>
+  <testsuites>
+    <testsuite name="WHMCS Sample Provisioning Module Tests">
+      <directory suffix=".php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/WHMCSModuleTest.php
+++ b/tests/WHMCSModuleTest.php
@@ -14,7 +14,7 @@
  * @copyright Copyright (c) WHMCS Limited 2017
  * @license http://www.whmcs.com/license/ WHMCS Eula
  */
-class WHMCSModuleTest extends PHPUnit_Framework_TestCase
+class WHMCSModuleTest extends \PHPUnit\Framework\TestCase
 {
     /** @var string $moduleName */
     protected $moduleName = 'provisioningmodule';

--- a/tests/WHMCSModuleTest.php
+++ b/tests/WHMCSModuleTest.php
@@ -34,7 +34,7 @@ class WHMCSModuleTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function providerFunctionReturnTypes()
+    public function providerFunctionReturnTypes(): array
     {
         return array(
             'Config Options' => array('ConfigOptions', 'array'),
@@ -64,7 +64,7 @@ class WHMCSModuleTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider providerFunctionReturnTypes
      */
-    public function testFunctionsReturnAppropriateDataType($function, $returnType)
+    public function testFunctionsReturnAppropriateDataType(string $function, string $returnType)
     {
         if (function_exists($this->moduleName . '_' . $function)) {
             $result = call_user_func($this->moduleName . '_' . $function, array());


### PR DESCRIPTION
Fix namespace and issue when trying to use testing
https://stackoverflow.com/a/42561590/1621381

error:
```
[docker://phpstorm/php-73-apache-xdebug-27/]:php /opt/project/vendor/phpunit/phpunit/phpunit --configuration /opt/project/phpunit.xml.dist --filter WHMCSModuleTest --test-suffix WHMCSModuleTest.php /opt/project/tests --teamcity
Testing started at 2:52 p.m. ...

Fatal error: Uncaught Error: Class 'PHPUnit_Framework_TestCase' not found in /opt/project/vendor/phpunit/phpunit/src/TextUI/Command.php on line 98

PHPUnit\TextUI\RuntimeException: Class 'PHPUnit_Framework_TestCase' not found in /opt/project/vendor/phpunit/phpunit/src/TextUI/Command.php on line 98

Call Stack:
    0.0005     401920   1. {main}() /opt/project/vendor/phpunit/phpunit/phpunit:0
    0.0077    1172000   2. PHPUnit\TextUI\Command::main() /opt/project/vendor/phpunit/phpunit/phpunit:76

Process finished with exit code 255
```

After updating works perfectly.
```
[docker://phpstorm/php-73-apache-xdebug-27/]:php /opt/project/vendor/phpunit/phpunit/phpunit --configuration /opt/project/phpunit.xml.dist --filter WHMCSModuleTest --test-suffix WHMCSModuleTest.php /opt/project/tests --teamcity
Testing started at 2:53 p.m. ...
PHPUnit 9.5.6 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!



Time: 00:00.035, Memory: 6.00 MB

OK (17 tests, 17 assertions)

Process finished with exit code 0
```